### PR TITLE
Add 3D plots of voltage over velocity-acceleration plane

### DIFF
--- a/data_analyzer.py
+++ b/data_analyzer.py
@@ -16,6 +16,7 @@ from os.path import basename, exists, dirname, join, splitext
 import numpy as np
 import matplotlib.pyplot as plt
 import statsmodels.api as sm
+from mpl_toolkits.mplot3d import Axes3D
 
 #
 # These parameters are used to indicate which column of data each parameter
@@ -296,6 +297,25 @@ def analyze_data(data, window=WINDOW):
 
         # Fix overlapping axis labels
         plt.tight_layout(pad=0.5)
+
+        # Interactive 3d plot of voltage over entire vel-accel plane
+        # Really cool, not really any more diagnostically-useful than prior plots but worth seeing
+
+        plt.figure(pfx + " 3D Vel-Accel Plane Plot")
+
+        ax = plt.subplot(111, projection='3d')
+
+        # 3D scatterplot
+        ax.set_xlabel("Velocity")
+        ax.set_ylabel("Acceleration")
+        ax.set_zlabel("Voltage")
+        ax.set_title("Voltage vs velocity and acceleration")
+        ax.scatter(vel, accel, volts)
+
+        # Show best fit plane
+
+        vv, aa = np.meshgrid(np.linspace(np.min(vel), np.max(vel)), np.linspace(np.min(accel), np.max(accel)))
+        ax.plot_surface(vv, aa, vi + kv * vv + ka * aa, alpha=.2, color=[0,1,1])
 
     # kv and vintercept is computed from the first two tests, ka from the latter
     _print(1, "Left forward  ", sf_l, ff_l)

--- a/data_analyzer.py
+++ b/data_analyzer.py
@@ -300,10 +300,9 @@ def analyze_data(data, window=WINDOW):
 
         # Interactive 3d plot of voltage over entire vel-accel plane
         # Really cool, not really any more diagnostically-useful than prior plots but worth seeing
-
         plt.figure(pfx + " 3D Vel-Accel Plane Plot")
 
-        ax = plt.subplot(111, projection='3d')
+        ax = plt.subplot(111, projection="3d")
 
         # 3D scatterplot
         ax.set_xlabel("Velocity")
@@ -313,9 +312,11 @@ def analyze_data(data, window=WINDOW):
         ax.scatter(vel, accel, volts)
 
         # Show best fit plane
-
-        vv, aa = np.meshgrid(np.linspace(np.min(vel), np.max(vel)), np.linspace(np.min(accel), np.max(accel)))
-        ax.plot_surface(vv, aa, vi + kv * vv + ka * aa, alpha=.2, color=[0,1,1])
+        vv, aa = np.meshgrid(
+            np.linspace(np.min(vel), np.max(vel)),
+            np.linspace(np.min(accel), np.max(accel)),
+        )
+        ax.plot_surface(vv, aa, vi + kv * vv + ka * aa, alpha=0.2, color=[0, 1, 1])
 
     # kv and vintercept is computed from the first two tests, ka from the latter
     _print(1, "Left forward  ", sf_l, ff_l)


### PR DESCRIPTION
Added interactive 3d plots of voltage over the entire velocity-acceleration plane, including both scatterplot and plane-of-best-fit as computed from the regression.  Very cool visualization that will help teams understand what the code is actually doing.