### PR TITLE
Fix dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ Required to use the data_logger.py/data_analyzer.py scripts.
 
 * Install Python 3.6 on your data gathering computer that will be connected to
   the robot's network
-* Once finished, install matplotlib and statsmodels
+* Once finished, install matplotlib, scipy, and statsmodels
 
 On Windows the command to install matplotlib and statsmodels is as follows:
 
-    py -3 -m pip install matplotlib statsmodels
+    py -3 -m pip install matplotlib scipy statsmodels
 
 Prerequisites (Robot)
 ---------------------


### PR DESCRIPTION
When I tried to run the most recent version of the script on my laptop (which had a fresh install of python), the scipy dependency was missing even after installing statsmodels.  This is kind of strange, because I was under the impression python packages install all of their dependencies, but it seems prudent to add this to be sure.